### PR TITLE
Feature/#467876 implementation of mobile screen size calibration

### DIFF
--- a/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSize.java
+++ b/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSize.java
@@ -1,7 +1,7 @@
 package com.onexip.plugins.capacitorscreensize;
 
 public class ScreenSize {
-
+/*
     public JSObject getDevicePPI() {
       DisplayMetrics displayMetrics = this.getActivity().getResources().getDisplayMetrics();
 
@@ -15,4 +15,6 @@ public class ScreenSize {
       return ret;
 
     }
+
+ */
 }

--- a/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSize.java
+++ b/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSize.java
@@ -1,20 +1,5 @@
 package com.onexip.plugins.capacitorscreensize;
 
 public class ScreenSize {
-/*
-    public JSObject getDevicePPI() {
-      DisplayMetrics displayMetrics = this.getActivity().getResources().getDisplayMetrics();
 
-      String xdpi = Float.toString(displayMetrics.xdpi);
-      String ydpi = Float.toString(displayMetrics.ydpi);
-
-      JSObject ret = new JSObject();
-      ret.put("xdpi", xdpi);
-      ret.put("ydpi", ydpi);
-
-      return ret;
-
-    }
-
- */
 }

--- a/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSizePlugin.java
+++ b/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSizePlugin.java
@@ -16,14 +16,18 @@ public class ScreenSizePlugin extends Plugin {
     public void getDevicePPI(PluginCall call) {
       DisplayMetrics displayMetrics = this.getActivity().getResources().getDisplayMetrics();
 
-      String xdpi = Float.toString(displayMetrics.xdpi);
+      //String density = Float.toString(displayMetrics.density);
+      float density = displayMetrics.density;
       String ydpi = Float.toString(displayMetrics.ydpi);
 
-      JSObject ret = new JSObject();
-      ret.put("xdpi", xdpi);
-      ret.put("ydpi", ydpi);
+      float scale = density / 160;
+      
 
-      //System.out.println("#### ret: " + ret.getString("xdpi") + ", " + ret.getString("ydpi"));
+      JSObject ret = new JSObject();
+      ret.put("density", ydpi);
+      ret.put("scaleFactor", scale);
+
+      System.out.println("#### density: " + ret.getString("density") + ", scaleFactor: " + ret.getString("scaleFactor"));
 
       call.resolve(ret);
 

--- a/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSizePlugin.java
+++ b/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSizePlugin.java
@@ -16,18 +16,14 @@ public class ScreenSizePlugin extends Plugin {
     public void getDevicePPI(PluginCall call) {
       DisplayMetrics displayMetrics = this.getActivity().getResources().getDisplayMetrics();
 
-      //String density = Float.toString(displayMetrics.density);
-      float density = displayMetrics.density;
+      String density = Float.toString(displayMetrics.density);
       String ydpi = Float.toString(displayMetrics.ydpi);
-
-      float scale = density / 160;
-      
 
       JSObject ret = new JSObject();
       ret.put("density", ydpi);
-      ret.put("scaleFactor", scale);
+      ret.put("scaleFactor", density);
 
-      System.out.println("#### density: " + ret.getString("density") + ", scaleFactor: " + ret.getString("scaleFactor"));
+      //System.out.println("#### density: " + ret.getString("density") + ", scaleFactor: " + ret.getString("scaleFactor"));
 
       call.resolve(ret);
 

--- a/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSizePlugin.java
+++ b/android/src/main/java/com/onexip/plugins/capacitorscreensize/ScreenSizePlugin.java
@@ -15,15 +15,13 @@ public class ScreenSizePlugin extends Plugin {
     @PluginMethod
     public void getDevicePPI(PluginCall call) {
       DisplayMetrics displayMetrics = this.getActivity().getResources().getDisplayMetrics();
-
-      String density = Float.toString(displayMetrics.density);
-      String ydpi = Float.toString(displayMetrics.ydpi);
+      
+      float density = displayMetrics.density;
+      float ydpi = displayMetrics.ydpi;
 
       JSObject ret = new JSObject();
       ret.put("density", ydpi);
       ret.put("scaleFactor", density);
-
-      //System.out.println("#### density: " + ret.getString("density") + ", scaleFactor: " + ret.getString("scaleFactor"));
 
       call.resolve(ret);
 

--- a/ios/Plugin/ScreenSizePlugin.swift
+++ b/ios/Plugin/ScreenSizePlugin.swift
@@ -25,16 +25,11 @@ public class ScreenSizePlugin: CAPPlugin {
 
         // get native scale factor from iOS device 
         let scale = UIScreen.main.nativeScale
-        
-        let ppiString = String(ppi)
-        let scaleString = "\(scale)"
 
-        
-        print("#### Plugin - Device PPI: ", ppiString)
 
         call.resolve([
-            "density": ppiString,
-            "scaleFactor": scaleString
+            "density": ppi,
+            "scaleFactor": scale
         ])
     }
 }

--- a/ios/Plugin/ScreenSizePlugin.swift
+++ b/ios/Plugin/ScreenSizePlugin.swift
@@ -22,13 +22,19 @@ public class ScreenSizePlugin: CAPPlugin {
                 return bestGuessPpi
             }
         }()
+
+        // get native scale factor from iOS device 
+        let scale = UIScreen.main.nativeScale
         
         let ppiString = String(ppi)
+        let scaleString = "\(scale)"
+
         
         print("#### Plugin - Device PPI: ", ppiString)
 
         call.resolve([
-            "ppi": ppiString
+            "density": ppiString,
+            "scaleFactor": scaleString
         ])
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,3 @@
 export interface ScreenSizePlugin {
-  getDevicePPI(): Promise<{ density: string }>;
+  getDevicePPI(): Promise<{ density: string, scaleFactor: string }>;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,3 @@
 export interface ScreenSizePlugin {
-  getDevicePPI(): Promise<{ density: string, scaleFactor: string }>;
+  getDevicePPI(): Promise<{ density: number, scaleFactor: number }>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,10 +4,11 @@ import type { ScreenSizePlugin } from './definitions';
 
 export class ScreenSizeWeb extends WebPlugin implements ScreenSizePlugin {
 
-  async getDevicePPI(): Promise<{ density: string }> {
+  async getDevicePPI(): Promise<{ density: string, scaleFactor: string }> {
     console.log('Accessing the PPI is not supported within a browser (web)!');
     return {
-      density: '0.0'
+      density: '0.0',
+      scaleFactor: '1.0'
     };
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,11 +4,11 @@ import type { ScreenSizePlugin } from './definitions';
 
 export class ScreenSizeWeb extends WebPlugin implements ScreenSizePlugin {
 
-  async getDevicePPI(): Promise<{ density: string, scaleFactor: string }> {
+  async getDevicePPI(): Promise<{ density: number, scaleFactor: number }> {
     console.log('Accessing the PPI is not supported within a browser (web)!');
     return {
-      density: '0.0',
-      scaleFactor: '1.0'
+      density: 0.0,
+      scaleFactor: 1.0
     };
   }
 


### PR DESCRIPTION
Adjusted functions to also return the native scale factor of mobile devices. The native scale factor in iOS is taken from:
- UIScreen.main.nativeScale
On Android the scale factor is taken from:
- DisplayMetrics.density

The scale factor in combination with the PPI can then be used to calculate the pixel pitch of the mobile device. 